### PR TITLE
Fixed export issue due to deprecated code

### DIFF
--- a/RenderdocResourceExporter/__init__.py
+++ b/RenderdocResourceExporter/__init__.py
@@ -55,7 +55,7 @@ def ExportFbx(pyrenderdoc_, data_):
 
     # 直接从 QTableView 界面获取数据
     main_window = pyrenderdoc_.GetMainWindow().Widget()
-    table = main_window.findChild(QtWidgets.QTableView, 'vsinData')
+    table = main_window.findChild(QtWidgets.QTableView, 'inTable')
     model = table.model()
     row_count = model.rowCount()
     column_count = model.columnCount()


### PR DESCRIPTION
I was getting this error

<img width="511" height="215" alt="image" src="https://github.com/user-attachments/assets/cf5ecc14-17ad-4d5f-a230-9d3134039461" />

Which I fixed now. Hope you accept my pull request :)